### PR TITLE
add --filename_suffix for timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ concat-all <file_extensions> [options]
 | `--output_file_dir`, `-D`   | Directory to save the output file                                                               | Current working directory      |
 | `--comment_prefix`, `-c`    | Prefix for comment headers before each file's content                                           | `//`                           |
 | `--gitignore`, `-i`         | Respect `.gitignore` rules when selecting files                                                 | Disabled                       |
-| `--force`, `-f`             | Overwrite output file if it already exists (otherwise timestamp will be appended)               | Disabled                       |
+| `--filename_suffix`         | Suffix to append to the output file name. Supports `{timestamp}` and `{unixtime}` placeholders. | Disabled                       |
 
 ---
 
@@ -96,6 +96,12 @@ Change the comment prefix to `#`:
 
 ```bash
 concat-all py -c "#"
+```
+
+Concatenate all `.py` files with a timestamp appended to the output file name:
+
+```bash
+concat-all py -o result.txt --filename_suffix "_{timestamp}"
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ concat-all <file_extensions> [options]
 | `--output_file_dir`, `-D`   | Directory to save the output file                                                               | Current working directory      |
 | `--comment_prefix`, `-c`    | Prefix for comment headers before each file's content                                           | `//`                           |
 | `--gitignore`, `-i`         | Respect `.gitignore` rules when selecting files                                                 | Disabled                       |
+| `--force`, `-f`             | Overwrite output file if it already exists (otherwise timestamp will be appended)               | Disabled                       |
 
 ---
 
@@ -121,7 +122,8 @@ concat_files(
     file_extensions="py,txt",
     output_file="./output/dump_{file_extension}.txt",
     comment_prefix="//",
-    use_gitignore=True
+    use_gitignore=True,
+    force=False
 )
 ```
 


### PR DESCRIPTION
- Append timestamp (sortable default format: YYYYMMDD_HHMMSS) to output filename if it already exists
- Add `--force` flag to allow explicit overwrite
- Avoids unintentional data loss when output already exists

## Summary by Sourcery

Add timestamp fallback for output file naming and introduce a --force flag to explicitly overwrite existing files

New Features:
- Append a sortable timestamp suffix to output filenames when a file already exists
- Add a --force/-f command-line flag to enable direct overwriting of existing output files

Documentation:
- Update README to document the new --force flag