### PR TITLE
feat: Enhance concat-all with multiple new features and improvements



### DIFF
--- a/concat_all/concat_all.py
+++ b/concat_all/concat_all.py
@@ -19,24 +19,62 @@ def should_ignore_path(path, gitignore_patterns=None):
     """
     if not gitignore_patterns:
         return False
+
+    path_str = str(pathlib.Path(path))  # Use a different variable name
+
+    negated_patterns = []
+    normal_patterns = []
+
+    for p in gitignore_patterns:
+        if p.startswith('!'):
+            negated_patterns.append(p[1:])
+        else:
+            normal_patterns.append(p)
+
+    # Check negated patterns first
+    for pattern_loop_var in negated_patterns:
+        temp_pattern = pattern_loop_var
+        if temp_pattern.startswith('/'):
+            temp_pattern = temp_pattern[1:]
         
-    # Convert path to relative path for matching
-    path = str(pathlib.Path(path))
-    
-    for pattern in gitignore_patterns:
-        if pattern.startswith('!'):  # Negated pattern
-            continue  # Skip negated patterns for simplicity
-        
-        # Remove leading slash from pattern for matching
-        if pattern.startswith('/'):
-            pattern = pattern[1:]
+        is_dir_pattern = temp_pattern.endswith('/')
+        if is_dir_pattern:
+            # Match "dir" itself if it's a directory
+            if os.path.isdir(path_str) and fnmatch.fnmatch(path_str, temp_pattern[:-1]):
+                return False # Don't ignore
+            # Match "dir/anything"
+            # Also matches "dir" itself if path_str is "dir" (fnmatch("dir", "dir/*") is false, fnmatch("dir", "dir") is true)
+            if fnmatch.fnmatch(path_str, temp_pattern[:-1] + '/*') or \
+               fnmatch.fnmatch(path_str, temp_pattern[:-1]):
+                # If path_str is "dir" (a file) and pattern is "dir/", 
+                # this file "dir" should not be unignored by the pattern "dir/".
+                if path_str == temp_pattern[:-1] and not os.path.isdir(path_str):
+                    pass 
+                else:
+                    return False # Don't ignore
+        elif fnmatch.fnmatch(path_str, temp_pattern):
+            return False # Don't ignore
+
+    # Check normal patterns
+    for pattern_loop_var in normal_patterns:
+        temp_pattern = pattern_loop_var
+        if temp_pattern.startswith('/'):
+            temp_pattern = temp_pattern[1:]
             
-        # Trailing slash means directory
-        if pattern.endswith('/'):
-            if os.path.isdir(path) and fnmatch.fnmatch(path, pattern[:-1] + '*'):
-                return True
-        elif fnmatch.fnmatch(path, pattern):
-            return True
+        is_dir_pattern = temp_pattern.endswith('/')
+        if is_dir_pattern:
+            # Match "dir" itself if it's a directory
+            if os.path.isdir(path_str) and fnmatch.fnmatch(path_str, temp_pattern[:-1]):
+                return True # Ignore
+            # Match "dir/anything"
+            if fnmatch.fnmatch(path_str, temp_pattern[:-1] + '/*') or \
+               fnmatch.fnmatch(path_str, temp_pattern[:-1]):
+                if path_str == temp_pattern[:-1] and not os.path.isdir(path_str):
+                    pass
+                else:
+                    return True # Ignore
+        elif fnmatch.fnmatch(path_str, temp_pattern):
+            return True # Ignore
             
     return False
 
@@ -63,7 +101,8 @@ def read_gitignore(dir_path):
     return patterns
 
 def concat_files(dir_path: str, file_extensions: str, output_file: str = './dump_{file_extension}.txt', 
-                comment_prefix: str = '//', use_gitignore: bool = False, filename_suffix: str = ''):
+                comment_prefix: str = '//', use_gitignore: bool = False, filename_suffix: str = '',
+                dry_run: bool = False, exclude_patterns: list = None, max_depth: int = -1):
     """
     Concatenate all files with the specified extension(s) under dir_path recursively
     and output to the specified output file.
@@ -96,8 +135,12 @@ def concat_files(dir_path: str, file_extensions: str, output_file: str = './dump
         base, ext = os.path.splitext(output_file)
         output_file = f"{base}{filename_suffix}{ext}"
 
-    if os.path.isfile(output_file):
-        os.remove(output_file)
+    if dry_run:
+        print("Dry run mode enabled.")
+        print(f"Output file would be: {os.path.abspath(output_file)}")
+    else:
+        if os.path.isfile(output_file):
+            os.remove(output_file)
     
     # Read gitignore if needed
     gitignore_patterns = []
@@ -108,17 +151,59 @@ def concat_files(dir_path: str, file_extensions: str, output_file: str = './dump
             gitignore_patterns.append('.git/')
         if '.gitignore' not in gitignore_patterns:
             gitignore_patterns.append('.gitignore')
+
+    if exclude_patterns is None:
+        exclude_patterns = []
     
     dir_path = os.path.abspath(dir_path)
+    # Calculate initial depth based on the absolute path
+    # Normalize dir_path to remove any trailing slash for consistent depth calculation
+    initial_depth = os.path.normpath(dir_path).count(os.sep)
+
     for root, dirs, files in os.walk(dir_path):
-        # Check if current directory should be ignored
-        if use_gitignore and should_ignore_path(os.path.relpath(root, dir_path), gitignore_patterns):
-            dirs[:] = []  # Don't traverse into ignored directories
+        current_abs_path = os.path.abspath(root)
+        # Calculate current depth
+        current_path_depth = os.path.normpath(current_abs_path).count(os.sep)
+        relative_depth = current_path_depth - initial_depth
+
+        # Apply max_depth logic
+        if max_depth != -1 and relative_depth >= max_depth:
+            if dry_run:
+                print(f"Max depth ({max_depth}) reached. Not traversing further from: {os.path.relpath(root, dir_path) or '.'}")
+            dirs[:] = [] # Prune subdirectories from further traversal
+
+        current_rel_dir_path = os.path.relpath(root, dir_path)
+        if current_rel_dir_path == ".": # Avoid "./" for root dir matching
+            current_rel_dir_path = ""
+
+        # Check if current directory should be ignored by gitignore (this should happen after depth check if depth is 0)
+        # If max_depth is 0, we process files in root, then clear dirs. Gitignore on root itself still applies.
+        if use_gitignore and should_ignore_path(current_rel_dir_path, gitignore_patterns):
+            if dry_run:
+                print(f"Ignoring directory (gitignore): {current_rel_dir_path if current_rel_dir_path else os.path.basename(root)}")
+            dirs[:] = [] # Also prune if gitignored
             continue
-            
+        
+        # Filter subdirectories based on --exclude patterns. This should also respect max_depth.
+        # If dirs are already cleared by max_depth, this loop won't run or won't matter.
+        original_dirs = list(dirs) 
+        dirs[:] = [] 
+        for d in original_dirs:
+            dir_rel_path = os.path.join(current_rel_dir_path, d)
+            excluded_by_custom_pattern = False
+            for pattern in exclude_patterns:
+                if fnmatch.fnmatch(dir_rel_path, pattern) or fnmatch.fnmatch(dir_rel_path + '/', pattern):
+                    if dry_run:
+                        print(f"Excluding directory (--exclude pattern '{pattern}'): {dir_rel_path}")
+                    excluded_by_custom_pattern = True
+                    break
+            if not excluded_by_custom_pattern:
+                dirs.append(d)
+        
         for file in files:
             file_path = os.path.join(root, file)
-            rel_path = os.path.relpath(file_path, dir_path)
+            # Use current_rel_dir_path for file's relative path to ensure consistency
+            rel_path = os.path.join(current_rel_dir_path, file) 
             
             # Skip the output file itself
             if os.path.abspath(file_path) == os.path.abspath(output_file):
@@ -126,6 +211,22 @@ def concat_files(dir_path: str, file_extensions: str, output_file: str = './dump
                 
             # Skip files matched by gitignore
             if use_gitignore and should_ignore_path(rel_path, gitignore_patterns):
+                if dry_run: # Optional: log gitignore skips for files too
+                    print(f"Ignoring file (gitignore): {rel_path}")
+                continue
+
+            # Skip files matched by --exclude patterns
+            excluded_by_user_pattern = False
+            for pattern in exclude_patterns:
+                if fnmatch.fnmatch(rel_path, pattern):
+                    if dry_run:
+                        print(f"Excluding file (--exclude pattern '{pattern}'): {rel_path}")
+                    else:
+                        # Optional: print even if not dry_run, as per instructions
+                        print(f"Excluding file (--exclude pattern '{pattern}'): {rel_path}")
+                    excluded_by_user_pattern = True
+                    break
+            if excluded_by_user_pattern:
                 continue
                 
             file_ext = os.path.splitext(file)[1]
@@ -134,14 +235,17 @@ def concat_files(dir_path: str, file_extensions: str, output_file: str = './dump
                 file_ext = file_ext[1:]
             
             if use_wildcard or file_ext in extensions:
-                try:
-                    with open(file_path, 'r', encoding='utf-8') as f:
-                        content = f.read()
-                    with open(output_file, 'a', encoding='utf-8') as dump_file:
-                        dump_file.write(f"{comment_prefix} File: {file_path}\n{content}\n\n")
-                except (UnicodeDecodeError, PermissionError, IsADirectoryError):
-                    # Skip binary files and files we can't read
-                    pass
+                if dry_run:
+                    print(f"Would concatenate: {file_path}")
+                else:
+                    try:
+                        with open(file_path, 'r', encoding='utf-8') as f:
+                            content = f.read()
+                        with open(output_file, 'a', encoding='utf-8') as dump_file:
+                            dump_file.write(f"{comment_prefix} File: {file_path}\n{content}\n\n")
+                    except (UnicodeDecodeError, PermissionError, IsADirectoryError):
+                        # Skip binary files and files we can't read
+                        pass
 
 def main():
     # Example usage
@@ -153,6 +257,9 @@ def main():
     parser.add_argument('--comment_prefix', '-c', type=str, help='Prefix for comments in the output file')
     parser.add_argument('--gitignore', '-i', action='store_true', help='Filter files using .gitignore')
     parser.add_argument('--filename_suffix', type=str, help='Suffix to append to the output filename (supports {timestamp}, {unixtime})')
+    parser.add_argument('--dry-run', '-n', action='store_true', help='Enable dry run mode. Shows files that would be concatenated without actually writing them.')
+    parser.add_argument('--exclude', type=str, help='Comma-separated list of glob patterns to exclude files/directories (e.g., "*.log,temp/*,specific_file.py")')
+    parser.add_argument('--max-depth', type=int, default=-1, help='Maximum recursion depth. 0 for current directory, 1 for current + direct children, etc. Default: -1 (unlimited).')
     args = parser.parse_args()
 
     kwargs = {}
@@ -170,6 +277,12 @@ def main():
         kwargs['use_gitignore'] = True
     if args.filename_suffix:
         kwargs['filename_suffix'] = args.filename_suffix
+    if args.dry_run:
+        kwargs['dry_run'] = True
+    if args.exclude:
+        kwargs['exclude_patterns'] = [p.strip() for p in args.exclude.split(',')]
+    if args.max_depth is not None: # Will always be true due to default, but good practice
+        kwargs['max_depth'] = args.max_depth
 
     concat_files(dir_path=kwargs.pop('dir_path'), file_extensions=args.file_extension, **kwargs)
     

--- a/tests/test_concat_all.py
+++ b/tests/test_concat_all.py
@@ -1,0 +1,266 @@
+import unittest
+import os
+import sys
+import tempfile
+import io
+import contextlib
+import shutil
+
+# Add project root to sys.path to allow importing concat_all
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from concat_all import concat_all
+
+class BaseTestCase(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.TemporaryDirectory()
+        self.test_dir_path = self.test_dir.name
+
+    def tearDown(self):
+        self.test_dir.cleanup()
+
+    def _create_files(self, file_dict):
+        """
+        Creates files and directories within the temporary test directory.
+        file_dict: A dictionary where keys are relative file paths
+                   and values are their content. Directories are created
+                   implicitly. If content is None, an empty directory is created.
+        """
+        for rel_path, content in file_dict.items():
+            full_path = os.path.join(self.test_dir_path, rel_path)
+            os.makedirs(os.path.dirname(full_path), exist_ok=True)
+            if content is not None:
+                with open(full_path, 'w', encoding='utf-8') as f:
+                    f.write(content)
+            else: # content is None, ensure directory exists
+                if not os.path.exists(full_path): # only if it's not implicitly created by another file
+                    os.makedirs(full_path, exist_ok=True)
+
+
+    def _run_concat_files(self, extensions="txt", output_file_name="concat_out.txt", **kwargs):
+        """
+        Runs concat_files and captures its stdout, then returns output file content and stdout.
+        """
+        output_file_path = os.path.join(self.test_dir_path, output_file_name)
+        
+        # Default kwargs for concat_files, can be overridden
+        run_kwargs = {
+            'dir_path': self.test_dir_path,
+            'file_extensions': extensions,
+            'output_file': output_file_path,
+            'comment_prefix': '//',
+        }
+        run_kwargs.update(kwargs)
+
+        stdout_capture = io.StringIO()
+        with contextlib.redirect_stdout(stdout_capture):
+            concat_all.concat_files(**run_kwargs)
+        
+        stdout_output = stdout_capture.getvalue()
+        
+        output_content = None
+        if os.path.exists(output_file_path):
+            with open(output_file_path, 'r', encoding='utf-8') as f:
+                output_content = f.read()
+                
+        return output_content, stdout_output
+
+class TestGitignoreHandling(BaseTestCase):
+    def test_general_ignore(self):
+        self._create_files({
+            ".gitignore": "*.log\ntemp/",
+            "file1.txt": "content1",
+            "file2.log": "log_content",
+            "temp/file3.txt": "temp_content",
+            "another.txt": "content_another"
+        })
+        content, _ = self._run_concat_files(use_gitignore=True)
+        self.assertIn("file1.txt", content)
+        self.assertIn("content1", content)
+        self.assertIn("another.txt", content)
+        self.assertIn("content_another", content)
+        self.assertNotIn("file2.log", content)
+        self.assertNotIn("log_content", content)
+        self.assertNotIn("temp/file3.txt", content)
+        self.assertNotIn("temp_content", content)
+
+    def test_negated_file_pattern(self):
+        self._create_files({
+            ".gitignore": "*.log\n!important.log",
+            "file1.txt": "content1",
+            "file2.log": "log_content_ignored",
+            "important.log": "log_content_important" # Should be included despite *.log
+        })
+        # Test with log extension to try and pick up important.log
+        content, _ = self._run_concat_files(extensions="txt,log", use_gitignore=True)
+        self.assertIn("file1.txt", content)
+        self.assertNotIn("file2.log", content)
+        self.assertIn("important.log", content)
+        self.assertIn("log_content_important", content)
+
+    def test_negated_directory_pattern(self):
+        self._create_files({
+            ".gitignore": "temp/\n!temp/keep_this/",
+            "file1.txt": "content1",
+            "temp/ignored_dir/ignore.txt": "ignored_in_temp",
+            "temp/keep_this/valuable.txt": "valuable_content",
+            "temp/another_ignored.txt": "also_ignored"
+        })
+        content, _ = self._run_concat_files(use_gitignore=True)
+        self.assertIn("file1.txt", content)
+        self.assertNotIn("ignored_dir/ignore.txt", content)
+        self.assertIn("temp/keep_this/valuable.txt", content) # Key assertion
+        self.assertIn("valuable_content", content)
+        self.assertNotIn("temp/another_ignored.txt", content)
+
+    def test_negation_overrides_general_within_path(self):
+        # Scenario: ignore all in 'build/', but not 'build/public/'
+        self._create_files({
+            ".gitignore": "build/\n!build/public/",
+            "main.txt": "main content",
+            "build/secret.txt": "secret",
+            "build/public/index.txt": "public index"
+        })
+        content, _ = self._run_concat_files(use_gitignore=True)
+        self.assertIn("main.txt", content)
+        self.assertNotIn("build/secret.txt", content)
+        self.assertIn("build/public/index.txt", content)
+        self.assertIn("public index", content)
+
+
+class TestDryRunMode(BaseTestCase):
+    def test_dry_run_output_and_no_file_creation(self):
+        self._create_files({
+            "file1.py": "print('hello')",
+            "subdir/file2.py": "print('world')"
+        })
+        output_content, stdout_output = self._run_concat_files(extensions="py", dry_run=True, output_file_name="dry_run_test.py")
+        
+        self.assertIsNone(output_content, "Output file should not be created in dry-run mode")
+        
+        self.assertIn("Dry run mode enabled.", stdout_output)
+        expected_output_path = os.path.join(self.test_dir_path, "dry_run_test.py")
+        self.assertIn(f"Output file would be: {expected_output_path}", stdout_output)
+        
+        # Normalize paths for comparison as os.walk order might vary slightly by OS
+        # and our concat might pick them up in different order.
+        # We care that both are mentioned.
+        path1 = os.path.join(self.test_dir_path, "file1.py")
+        path2 = os.path.join(self.test_dir_path, "subdir", "file2.py")
+        self.assertIn(f"Would concatenate: {path1}", stdout_output)
+        self.assertIn(f"Would concatenate: {path2}", stdout_output)
+
+class TestExcludeOption(BaseTestCase):
+    def test_exclude_specific_file(self):
+        self._create_files({
+            "file1.txt": "content1",
+            "file_to_exclude.txt": "exclude_me",
+            "file3.txt": "content3"
+        })
+        exclude_patterns = ["file_to_exclude.txt"]
+        content, _ = self._run_concat_files(exclude_patterns=exclude_patterns)
+        self.assertIn("file1.txt", content)
+        self.assertNotIn("file_to_exclude.txt", content)
+        self.assertIn("file3.txt", content)
+
+    def test_exclude_by_glob_pattern(self):
+        self._create_files({
+            "file1.txt": "content1",
+            "file.log": "log_data",
+            "another.txt": "content_A",
+            "another.log": "log_data_2"
+        })
+        exclude_patterns = ["*.log"]
+        # Concatenate all files initially to check exclusion
+        content, _ = self._run_concat_files(extensions="*", exclude_patterns=exclude_patterns)
+        self.assertIn("file1.txt", content)
+        self.assertNotIn("file.log", content)
+        self.assertIn("another.txt", content)
+        self.assertNotIn("another.log", content)
+
+    def test_exclude_directory(self):
+        self._create_files({
+            "file1.txt": "content1",
+            "build/file_in_build.txt": "build_content",
+            "src/file_in_src.txt": "src_content",
+            "build/another.txt": "build_content2"
+        })
+        exclude_patterns = ["build/"] # or "build/*" or "build"
+        content, _ = self._run_concat_files(extensions="txt", exclude_patterns=exclude_patterns)
+        self.assertIn("file1.txt", content)
+        self.assertNotIn("build/file_in_build.txt", content)
+        self.assertNotIn("build_content", content)
+        self.assertIn("src/file_in_src.txt", content)
+
+    def test_exclude_pattern_relative_to_root(self):
+        self._create_files({
+            "src/app1/main.py": "app1",
+            "src/app2/main.py": "app2",
+            "src/app1/utils.py": "app1_utils"
+        })
+        # Exclude all main.py files inside any subdirectory of src
+        exclude_patterns = ["src/*/main.py"]
+        content, _ = self._run_concat_files(extensions="py", exclude_patterns=exclude_patterns)
+        self.assertNotIn("src/app1/main.py", content)
+        self.assertNotIn("src/app2/main.py", content)
+        self.assertIn("src/app1/utils.py", content)
+
+class TestMaxDepthOption(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self._create_files({
+            "root.txt": "root_content",
+            "level1_dir/level1.txt": "level1_content",
+            "level1_dir/level2_dir/level2.txt": "level2_content",
+            "level1_dir/level2_dir/level3_dir/level3.txt": "level3_content",
+            "another_level1_dir/another_level1.txt": "another_l1_content"
+        })
+
+    def test_max_depth_0(self):
+        content, _ = self._run_concat_files(max_depth=0)
+        self.assertIn("root.txt", content)
+        self.assertNotIn("level1.txt", content)
+        self.assertNotIn("level2.txt", content)
+        self.assertNotIn("level3.txt", content)
+        self.assertNotIn("another_level1.txt", content)
+
+    def test_max_depth_1(self):
+        content, _ = self._run_concat_files(max_depth=1)
+        self.assertIn("root.txt", content)
+        self.assertIn("level1.txt", content)
+        self.assertIn("another_level1.txt", content)
+        self.assertNotIn("level2.txt", content)
+        self.assertNotIn("level3.txt", content)
+
+    def test_max_depth_2(self):
+        content, _ = self._run_concat_files(max_depth=2)
+        self.assertIn("root.txt", content)
+        self.assertIn("level1.txt", content)
+        self.assertIn("another_level1.txt", content)
+        self.assertIn("level2.txt", content)
+        self.assertNotIn("level3.txt", content)
+        
+    def test_max_depth_unlimited(self): # default is -1
+        content, _ = self._run_concat_files() # max_depth=-1 by default in concat_files
+        self.assertIn("root.txt", content)
+        self.assertIn("level1.txt", content)
+        self.assertIn("another_level1.txt", content)
+        self.assertIn("level2.txt", content)
+        self.assertIn("level3.txt", content)
+
+    def test_max_depth_stdout_message_dry_run(self):
+        _, stdout = self._run_concat_files(max_depth=0, dry_run=True)
+        # Path is relative to test_dir_path, which is "." for root in this context
+        self.assertIn("Max depth (0) reached. Not traversing further from: .", stdout)
+
+        _, stdout_l1 = self._run_concat_files(max_depth=1, dry_run=True)
+        # Check for one of the level1 dirs
+        path_l1d = os.path.join("level1_dir") 
+        # The message should appear for each directory at max_depth
+        self.assertIn(f"Max depth (1) reached. Not traversing further from: {path_l1d}", stdout_l1)
+        path_al1d = os.path.join("another_level1_dir")
+        self.assertIn(f"Max depth (1) reached. Not traversing further from: {path_al1d}", stdout_l1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit introduces several enhancements to the concat-all tool, making it more versatile and user-friendly for you:

1.  **Enhanced .gitignore Handling:**
    *   The tool now correctly processes negated patterns in `.gitignore` files (e.g., `!important.log`), allowing for more precise control over ignored files.

2.  **Dry-Run Mode:**
    *   Added a `--dry-run` (or `-n`) option. When used, the tool lists all files that would be concatenated and the intended output file path without performing any actual file operations. This is useful for you to verify selections before writing.

3.  **Exclude Option:**
    *   Introduced an `--exclude <patterns>` option. You can provide a comma-separated list of glob patterns to exclude specific files or directories from concatenation. This filter is applied after `.gitignore` rules.

4.  **Max Depth Control:**
    *   Added a `--max-depth <depth>` option to limit the recursion depth when searching for files.
        *   `0`: Only files in the specified root directory.
        *   `1`: Files in the root and its direct subdirectories, etc.
        *   `-1` (default): Unlimited depth.

5.  **Documentation:**
    *   The `README.md` has been updated to reflect all new features, including descriptions of the new CLI options and usage examples.

6.  **Unit Tests:**
    *   A comprehensive suite of unit tests (`tests/test_concat_all.py`) has been added using the `unittest` framework. These tests cover the new functionalities (.gitignore negation, dry-run, exclude, max-depth) and various edge cases to ensure robustness and prevent regressions.

## Summary by Sourcery

Enhance concat-all with advanced file selection controls and new operational modes, update documentation, and add tests for robustness.

New Features:
- Support negated patterns in .gitignore for precise file inclusion
- Add --dry-run (-n) mode to preview files and output path without writing
- Introduce --exclude option to skip files or directories via glob patterns
- Add --max-depth option to limit recursion depth when searching for files

Documentation:
- Update README with descriptions and examples for new CLI options (dry-run, exclude, max-depth)

Tests:
- Add unit tests covering .gitignore negation, dry-run mode, exclusion patterns, and max-depth behavior