### PR TITLE
Fix CLI output directory

### DIFF
--- a/concat_all/concat_all.py
+++ b/concat_all/concat_all.py
@@ -231,13 +231,16 @@ def main():
 
     kwargs = {}
     kwargs['dir_path'] = args.dir_path if args.dir_path else os.getcwd()
+
+    output_file = args.output_file
     if args.output_file_dir:
         os.makedirs(args.output_file_dir, exist_ok=True)
-        if not args.output_file:
-            args.output_file = 'dump_{file_extension}.txt'
-        kwargs['output_file'] = os.path.join(args.output_file_dir, args.output_file)
-    if args.output_file:
-        kwargs['output_file'] = args.output_file
+        if not output_file:
+            output_file = 'dump_{file_extension}.txt'
+        output_file = os.path.join(args.output_file_dir, output_file)
+
+    if output_file:
+        kwargs['output_file'] = output_file
     if args.comment_prefix:
         kwargs['comment_prefix'] = args.comment_prefix
     if args.gitignore:

--- a/tests/test_concat_all.py
+++ b/tests/test_concat_all.py
@@ -262,5 +262,27 @@ class TestMaxDepthOption(BaseTestCase):
         self.assertIn(f"Max depth (1) reached. Not traversing further from: {path_al1d}", stdout_l1)
 
 
+class TestMainOutputDir(BaseTestCase):
+    def test_output_file_dir_with_default_name(self):
+        self._create_files({"file1.txt": "content1"})
+        output_dir = os.path.join(self.test_dir_path, "out")
+
+        stdout_capture = io.StringIO()
+        prev_argv = sys.argv
+        sys.argv = ["concat-all", "txt", "-d", self.test_dir_path, "-D", output_dir]
+        try:
+            with contextlib.redirect_stdout(stdout_capture):
+                concat_all.main()
+        finally:
+            sys.argv = prev_argv
+
+        output_file_path = os.path.join(output_dir, "dump_txt.txt")
+        self.assertTrue(os.path.exists(output_file_path))
+        with open(output_file_path, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        self.assertIn("file1.txt", content)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- handle `--output_file_dir` correctly in CLI
- test default output filename when using `-D`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68433e1c88b4832cbb5fe7e351a190f6

## Summary by Sourcery

Fix the CLI to correctly apply the output directory flag and ensure default output files are named properly when using `--output_file_dir`

Bug Fixes:
- Fix handling of the `--output_file_dir` option to prepend the directory and apply default filename when none is provided

Tests:
- Add a test to verify the default output filename is used and created in the specified output directory with the `-D` flag